### PR TITLE
Improved memory performance whilst parsing

### DIFF
--- a/Classes/MWFeedParser.m
+++ b/Classes/MWFeedParser.m
@@ -432,6 +432,7 @@
 									   qualifiedName:(NSString *)qualifiedName attributes:(NSDictionary *)attributeDict {
 	MWXMLLog(@"NSXMLParser: didStartElement: %@", qualifiedName);
 	
+	NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
 	// Adjust path
 	self.currentPath = [currentPath stringByAppendingPathComponent:qualifiedName];
 	self.currentElementAttributes = attributeDict;
@@ -549,12 +550,14 @@
 		
 	}
 	
+	[pool release];
 }
 
 - (void)parser:(NSXMLParser *)parser didEndElement:(NSString *)elementName 
 									  namespaceURI:(NSString *)namespaceURI qualifiedName:(NSString *)qName {
 	MWXMLLog(@"NSXMLParser: didEndElement: %@", qName);
 	
+	NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
 	// Parse content as structure (Atom feeds with element type="xhtml")
 	// - Use elementName not qualifiedName to ignore XML namespaces for XHTML entities
 	if (parseStructureAsContent) {
@@ -685,6 +688,8 @@
 			
 		}	
 	}
+	
+	[pool release];
 	
 }
 


### PR DESCRIPTION
I found that memory was spiking quite high whilst parsing certain large feeds. On analysis this turned out to be mostly objects that were created during the parsing process but not released until the auto release pool was cleared. I improved this by creating auto release pools during parsing and releasing them early so that memory is freed as soon as possible.

In my project I found this has reduced the peak allocation cost from about 12 MB to 4 MB and has reduced the likelyhood of memory warnings from iOS

(love the library btw)
