### PR TITLE
Feed URL property changed to NSURL

### DIFF
--- a/Classes/MWFeedParser.h
+++ b/Classes/MWFeedParser.h
@@ -85,7 +85,7 @@ typedef enum { FeedTypeUnknown, FeedTypeRSS, FeedTypeRSS1, FeedTypeAtom } FeedTy
 	NSDateFormatter *dateFormatterRFC822, *dateFormatterRFC3339;
 	
 	// Parsing State
-	NSString *url;
+	NSURL *url;
 	BOOL aborted; // Whether parse stopped due to abort
 	BOOL parsing; // Whether the MWFeedParser has started parsing
 	BOOL stopped; // Whether the parse was stopped
@@ -128,8 +128,8 @@ typedef enum { FeedTypeUnknown, FeedTypeRSS, FeedTypeRSS1, FeedTypeAtom } FeedTy
 
 #pragma mark Public Methods
 
-// Init MWFeedParser with a URL string
-- (id)initWithFeedURL:(NSString *)feedURL;
+// Init MWFeedParser with a URL
+- (id)initWithFeedURL:(NSURL *)feedURL;
 
 // Begin parsing
 - (BOOL)parse;
@@ -138,6 +138,6 @@ typedef enum { FeedTypeUnknown, FeedTypeRSS, FeedTypeRSS1, FeedTypeAtom } FeedTy
 - (void)stopParsing;
 
 // Returns the URL
-- (NSString *)url;
+- (NSURL *)url;
 
 @end

--- a/Classes/MWFeedParser.m
+++ b/Classes/MWFeedParser.m
@@ -59,7 +59,7 @@
 #pragma mark NSObject
 
 - (id)init {
-	if (self = [super init]) {
+	if ((self = [super init])) {
 
 		// Defaults
 		feedParseType = ParseTypeFull;
@@ -82,8 +82,8 @@
 
 // Initialise with a URL
 // Mainly for historic reasons before -parseURL:
-- (id)initWithFeedURL:(NSString *)feedURL {
-	if (self = [self init]) {
+- (id)initWithFeedURL:(NSURL *)feedURL {
+	if ((self = [self init])) {
 		
 		// Remember url
 		self.url = feedURL;
@@ -150,7 +150,7 @@
 	BOOL success = YES;
 	
 	// Request
-	NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:url] 
+	NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:url
 												  cachePolicy:NSURLRequestReloadIgnoringLocalAndRemoteCacheData 
 											  timeoutInterval:60];
 	[request setValue:@"MWFeedParser" forHTTPHeaderField:@"User-Agent"];
@@ -167,7 +167,7 @@
 			asyncData = [[NSMutableData alloc] init];// Create data
 		} else {
 			[self parsingFailedWithErrorCode:MWErrorCodeConnectionFailed 
-							  andDescription:[NSString stringWithFormat:@"Asynchronous connection failed to URL: %@", url]];
+							  andDescription:[NSString stringWithFormat:@"Asynchronous connection failed to URL: %@", [url description]]];
 			success = NO;
 		}
 		
@@ -181,7 +181,7 @@
 			[self startParsingData:data textEncodingName:[response textEncodingName]]; // Process
 		} else {
 			[self parsingFailedWithErrorCode:MWErrorCodeConnectionFailed 
-							  andDescription:[NSString stringWithFormat:@"Synchronous connection failed to URL: %@", url]];
+							  andDescription:[NSString stringWithFormat:@"Synchronous connection failed to URL: %@", [url description]]];
 			success = NO;
 		}
 		
@@ -837,13 +837,17 @@
 
 // Set URL to parse and removing feed: uri scheme info
 // http://en.wikipedia.org/wiki/Feed:_URI_scheme
-- (void)setUrl:(NSString *)value {
-	NSString *newURL = nil;
+- (void)setUrl:(NSURL *)value {
+	NSURL *newURL = nil;
 	if (value) {
-		newURL = [NSString stringWithString:value];
-		if ([newURL hasPrefix:@"feed://"]) newURL = [NSString stringWithFormat:@"http://%@", [newURL substringFromIndex:7]];
-		if ([newURL hasPrefix:@"feed:"]) newURL = [newURL substringFromIndex:5];
-	}
+        if ([[value scheme] isEqualToString:@"feed"]) {
+            newURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@%@", 
+                                           ([[value resourceSpecifier] hasPrefix:@"//"] ? @"http:" : @""),
+                                           [value resourceSpecifier]]];
+        } else {
+            newURL = [[value copy] autorelease];
+        }
+ 	}
 	if (url) [url release];
 	url = [newURL retain];
 }

--- a/Classes/MWFeedParser_Private.h
+++ b/Classes/MWFeedParser_Private.h
@@ -32,7 +32,7 @@
 #pragma mark Private Properties
 
 // Feed Downloading Properties
-@property (nonatomic, copy) NSString *url;
+@property (nonatomic, copy) NSURL *url;
 @property (nonatomic, retain) NSURLConnection *urlConnection;
 @property (nonatomic, retain) NSMutableData *asyncData;
 @property (nonatomic, retain) NSString *asyncTextEncodingName;

--- a/Classes/RootViewController.m
+++ b/Classes/RootViewController.m
@@ -57,7 +57,7 @@
 																							target:self 
 																							action:@selector(refresh)] autorelease];
 	// Create parser
-	feedParser = [[MWFeedParser alloc] initWithFeedURL:@"http://images.apple.com/main/rss/hotnews/hotnews.rss"];
+	feedParser = [[MWFeedParser alloc] initWithFeedURL:[NSURL URLWithString:@"http://images.apple.com/main/rss/hotnews/hotnews.rss"]];
 	feedParser.delegate = self;
 	feedParser.feedParseType = ParseTypeFull; // Parse feed info and all items
 	feedParser.connectionType = ConnectionTypeAsynchronously;

--- a/README.markdown
+++ b/README.markdown
@@ -38,7 +38,7 @@ There is an example iPhone application within the project which demonstrates how
 Create parser:
 
 	// Create feed parser and pass the URL of the feed
-	feedParser = [[MWFeedParser alloc] initWithFeedURL:@"http://images.apple.com/main/rss/hotnews/hotnews.rss"];
+	feedParser = [[MWFeedParser alloc] initWithFeedURL:[NSURL URLWithString:@"http://images.apple.com/main/rss/hotnews/hotnews.rss"]];
 
 Set delegate:
 


### PR DESCRIPTION
I changed the feed URL type from NSString to NSURL. I use it to load cached RSS feeds from a local path source. The implementation also fixes the "feed://..." and "feed:https://" schemes properly.
