### PR TITLE
Deprecation Warning.

### DIFF
--- a/Classes/NSString+HTML.h
+++ b/Classes/NSString+HTML.h
@@ -41,6 +41,6 @@
 - (NSString *)stringByRemovingNewLinesAndWhitespace;
 
 // DEPRECIATED - Please use NSString stringByConvertingHTMLToPlainText
-- (NSString *)stringByStrippingTags; 
+- (NSString *)stringByStrippingTags NS_DEPRECATED(10_0, 10_4, 4_0, 4_0);
 
 @end


### PR DESCRIPTION
I've added a warning to the stringByStrippingTags method to warn people that it's deprecated when they're using it.
