### PR TITLE
Add ability to parse from NSData

### DIFF
--- a/Classes/MWFeedParser.h
+++ b/Classes/MWFeedParser.h
@@ -50,7 +50,7 @@
 @class MWFeedParser;
 
 // Types
-typedef enum { ConnectionTypeAsynchronously, ConnectionTypeSynchronously } ConnectionType;
+typedef enum { ConnectionTypeAsynchronously, ConnectionTypeSynchronously, ConnectionTypeLocalData } ConnectionType;
 typedef enum { ParseTypeFull, ParseTypeItemsOnly, ParseTypeInfoOnly } ParseType;
 typedef enum { FeedTypeUnknown, FeedTypeRSS, FeedTypeRSS1, FeedTypeAtom } FeedType;
 
@@ -74,8 +74,8 @@ typedef enum { FeedTypeUnknown, FeedTypeRSS, FeedTypeRSS1, FeedTypeAtom } FeedTy
 	
 	// Connection
 	NSURLConnection *urlConnection;
-	NSMutableData *asyncData;
-	NSString *asyncTextEncodingName;
+	NSMutableData *xmlData;
+	NSString *xmlTextEncodingName;
 	ConnectionType connectionType;
 	
 	// Parsing
@@ -130,6 +130,7 @@ typedef enum { FeedTypeUnknown, FeedTypeRSS, FeedTypeRSS1, FeedTypeAtom } FeedTy
 
 // Init MWFeedParser with a URL string
 - (id)initWithFeedURL:(NSURL *)feedURL;
+- (id)initWithFeedData:(NSData *)data textEncodingName:(NSString *)textEncodingName;
 
 // Begin parsing
 - (BOOL)parse;

--- a/Classes/MWFeedParser.m
+++ b/Classes/MWFeedParser.m
@@ -50,7 +50,7 @@
 
 // Properties
 @synthesize url, delegate;
-@synthesize urlConnection, asyncData, asyncTextEncodingName, connectionType;
+@synthesize urlConnection, xmlData, xmlTextEncodingName, connectionType;
 @synthesize feedParseType, feedParser, currentPath, currentText, currentElementAttributes, item, info;
 @synthesize pathOfElementWithXHTMLType;
 @synthesize stopped, failed, parsing;
@@ -97,6 +97,15 @@
 	return self;
 }
 
+- (id)initWithFeedData:(NSData *)data textEncodingName:(NSString *)textEncodingName {
+    if ((self = [self init])) {
+		connectionType = ConnectionTypeLocalData;
+        self.xmlData = [NSMutableData dataWithData:data];
+        self.xmlTextEncodingName = textEncodingName;
+	}
+	return self;
+}
+
 - (void)dealloc {
 	[urlConnection release];
 	[url release];
@@ -117,9 +126,12 @@
 
 // Reset data variables before processing
 // Exclude parse state variables as they are needed after parse
+// Exclude data and encoding if using local data
 - (void)reset {
-	self.asyncData = nil;
-	self.asyncTextEncodingName = nil;
+    if(connectionType != ConnectionTypeLocalData) {
+        self.xmlData = nil;
+        self.xmlTextEncodingName = nil;
+    }
 	self.urlConnection = nil;
 	feedType = FeedTypeUnknown;
 	self.currentPath = @"/";
@@ -139,7 +151,7 @@
 	[self reset];
 	
 	// Perform checks before parsing
-	if (!url || !delegate) { [self parsingFailedWithErrorCode:MWErrorCodeNotInitiated 
+	if (connectionType!=ConnectionTypeLocalData && (!url || !delegate)) { [self parsingFailedWithErrorCode:MWErrorCodeNotInitiated 
 											   andDescription:@"Delegate or URL not specified"]; return NO; }
 	if (parsing) { [self parsingFailedWithErrorCode:MWErrorCodeGeneral 
 									 andDescription:@"Cannot start parsing as parsing is already in progress"]; return NO; }
@@ -169,14 +181,14 @@
 		// Async
 		urlConnection = [[NSURLConnection alloc] initWithRequest:request delegate:self];
 		if (urlConnection) {
-			asyncData = [[NSMutableData alloc] init];// Create data
+			xmlData = [[NSMutableData alloc] init];// Create data
 		} else {
 			[self parsingFailedWithErrorCode:MWErrorCodeConnectionFailed 
 							  andDescription:[NSString stringWithFormat:@"Asynchronous connection failed to URL: %@", url]];
 			success = NO;
 		}
 		
-	} else {
+	} else if (connectionType == ConnectionTypeSynchronously) {
 	
 		// Sync
 		NSURLResponse *response = nil;
@@ -190,7 +202,10 @@
 			success = NO;
 		}
 		
-	}
+	} else {
+        // Local data (no request)
+        [self startParsingData:self.xmlData textEncodingName:self.xmlTextEncodingName];
+    }
 	
 	// Cleanup & return
 	[request release];
@@ -317,8 +332,8 @@
 		// Stop downloading
 		[urlConnection cancel];
 		self.urlConnection = nil;
-		self.asyncData = nil;
-		self.asyncTextEncodingName = nil;
+		self.xmlData = nil;
+		self.xmlTextEncodingName = nil;
 		
 		// Abort
 		aborted = YES;
@@ -389,20 +404,20 @@
 #pragma mark NSURLConnection Delegate (Async)
 
 - (void)connection:(NSURLConnection *)connection didReceiveResponse:(NSURLResponse *)response {
-	[asyncData setLength:0];
-	self.asyncTextEncodingName = [response textEncodingName];
+	[xmlData setLength:0];
+	self.xmlTextEncodingName = [response textEncodingName];
 }
 
 - (void)connection:(NSURLConnection *)connection didReceiveData:(NSData *)data {
-	[asyncData appendData:data];
+	[xmlData appendData:data];
 }
 
 - (void)connection:(NSURLConnection *)connection didFailWithError:(NSError *)error {
 	
 	// Failed
 	self.urlConnection = nil;
-	self.asyncData = nil;
-	self.asyncTextEncodingName = nil;
+	self.xmlData = nil;
+	self.xmlTextEncodingName = nil;
 	
     // Error
 	[self parsingFailedWithErrorCode:MWErrorCodeConnectionFailed andDescription:[error localizedDescription]];
@@ -412,15 +427,15 @@
 - (void)connectionDidFinishLoading:(NSURLConnection *)connection {
 	
 	// Succeed
-	MWLog(@"MWFeedParser: Connection successful... received %d bytes of data", [asyncData length]);
+	MWLog(@"MWFeedParser: Connection successful... received %d bytes of data", [xmlData length]);
 	
 	// Parse
-	if (!stopped) [self startParsingData:asyncData textEncodingName:self.asyncTextEncodingName];
+	if (!stopped) [self startParsingData:xmlData textEncodingName:self.xmlTextEncodingName];
 	
     // Cleanup
     self.urlConnection = nil;
-    self.asyncData = nil;
-	self.asyncTextEncodingName = nil;
+    self.xmlData = nil;
+	self.xmlTextEncodingName = nil;
 
 }
 

--- a/Classes/MWFeedParser_Private.h
+++ b/Classes/MWFeedParser_Private.h
@@ -34,8 +34,8 @@
 // Feed Downloading Properties
 @property (nonatomic, copy) NSURL *url;
 @property (nonatomic, retain) NSURLConnection *urlConnection;
-@property (nonatomic, retain) NSMutableData *asyncData;
-@property (nonatomic, retain) NSString *asyncTextEncodingName;
+@property (nonatomic, retain) NSMutableData *xmlData;
+@property (nonatomic, retain) NSString *xmlTextEncodingName;
 
 // Parsing Properties
 @property (nonatomic, retain) NSXMLParser *feedParser;


### PR DESCRIPTION
The ability to parse XML retrieved from a source other then a URL is useful in many cases.  This adds the ability to use a local NSData object as the contents to be parsed instead of from NSURL.
