### PR TITLE
Fix compiler error "Format specifies type 'unsigned short' but the argument has type 'int'"

### DIFF
--- a/Classes/NSString+HTML.m
+++ b/Classes/NSString+HTML.m
@@ -162,7 +162,7 @@
 	NSMutableString *result = [[NSMutableString alloc] init];
 	NSString *temp;
 	NSCharacterSet *newLineCharacters = [NSCharacterSet characterSetWithCharactersInString:
-										 [NSString stringWithFormat:@"\n\r%C%C%C%C", 0x0085, 0x000C, 0x2028, 0x2029]];
+										 [NSString stringWithFormat:@"\n\r%c%c%c%c", 0x0085, 0x000C, 0x2028, 0x2029]];
 	// Scan
 	do {
 		
@@ -221,7 +221,7 @@
 	NSMutableString *result = [[NSMutableString alloc] init];
 	NSString *temp;
 	NSCharacterSet *newLineAndWhitespaceCharacters = [NSCharacterSet characterSetWithCharactersInString:
-													  [NSString stringWithFormat:@" \t\n\r%C%C%C%C", 0x0085, 0x000C, 0x2028, 0x2029]];
+													  [NSString stringWithFormat:@" \t\n\r%c%c%c%c", 0x0085, 0x000C, 0x2028, 0x2029]];
 	// Scan
 	while (![scanner isAtEnd]) {
 		

--- a/Classes/NSString+HTML.m
+++ b/Classes/NSString+HTML.m
@@ -40,8 +40,8 @@
 	NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
 	
 	// Character sets
-	NSCharacterSet *stopCharacters = [NSCharacterSet characterSetWithCharactersInString:[NSString stringWithFormat:@"< \t\n\r%c%c%c%c", 0x0085, 0x000C, 0x2028, 0x2029]];
-	NSCharacterSet *newLineAndWhitespaceCharacters = [NSCharacterSet characterSetWithCharactersInString:[NSString stringWithFormat:@" \t\n\r%c%c%c%c", 0x0085, 0x000C, 0x2028, 0x2029]];
+	NSCharacterSet *stopCharacters = [NSCharacterSet characterSetWithCharactersInString:[NSString stringWithFormat:@"< \t\n\r%C%C%C%C", (unichar)0x0085, (unichar)0x000C, (unichar)0x2028, (unichar)0x2029]];
+	NSCharacterSet *newLineAndWhitespaceCharacters = [NSCharacterSet characterSetWithCharactersInString:[NSString stringWithFormat:@" \t\n\r%C%C%C%C", (unichar)0x0085, (unichar)0x000C, (unichar)0x2028, (unichar)0x2029]];
 	NSCharacterSet *tagNameCharacters = [NSCharacterSet characterSetWithCharactersInString:@"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"];
 	
 	// Scan and find all tags
@@ -162,7 +162,7 @@
 	NSMutableString *result = [[NSMutableString alloc] init];
 	NSString *temp;
 	NSCharacterSet *newLineCharacters = [NSCharacterSet characterSetWithCharactersInString:
-										 [NSString stringWithFormat:@"\n\r%c%c%c%c", 0x0085, 0x000C, 0x2028, 0x2029]];
+										 [NSString stringWithFormat:@"\n\r%C%C%C%C", (unichar)0x0085, (unichar)0x000C, (unichar)0x2028, (unichar)0x2029]];
 	// Scan
 	do {
 		
@@ -221,7 +221,7 @@
 	NSMutableString *result = [[NSMutableString alloc] init];
 	NSString *temp;
 	NSCharacterSet *newLineAndWhitespaceCharacters = [NSCharacterSet characterSetWithCharactersInString:
-													  [NSString stringWithFormat:@" \t\n\r%c%c%c%c", 0x0085, 0x000C, 0x2028, 0x2029]];
+													  [NSString stringWithFormat:@" \t\n\r%C%C%C%C", (unichar)0x0085, (unichar)0x000C, (unichar)0x2028, (unichar)0x2029]];
 	// Scan
 	while (![scanner isAtEnd]) {
 		

--- a/Classes/NSString+HTML.m
+++ b/Classes/NSString+HTML.m
@@ -40,8 +40,8 @@
 	NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
 	
 	// Character sets
-	NSCharacterSet *stopCharacters = [NSCharacterSet characterSetWithCharactersInString:[NSString stringWithFormat:@"< \t\n\r%C%C%C%C", 0x0085, 0x000C, 0x2028, 0x2029]];
-	NSCharacterSet *newLineAndWhitespaceCharacters = [NSCharacterSet characterSetWithCharactersInString:[NSString stringWithFormat:@" \t\n\r%C%C%C%C", 0x0085, 0x000C, 0x2028, 0x2029]];
+	NSCharacterSet *stopCharacters = [NSCharacterSet characterSetWithCharactersInString:[NSString stringWithFormat:@"< \t\n\r%c%c%c%c", 0x0085, 0x000C, 0x2028, 0x2029]];
+	NSCharacterSet *newLineAndWhitespaceCharacters = [NSCharacterSet characterSetWithCharactersInString:[NSString stringWithFormat:@" \t\n\r%c%c%c%c", 0x0085, 0x000C, 0x2028, 0x2029]];
 	NSCharacterSet *tagNameCharacters = [NSCharacterSet characterSetWithCharactersInString:@"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"];
 	
 	// Scan and find all tags


### PR DESCRIPTION
Use %c not %d as %d results in the int value being used (%d is what xcode puts in if you let it fix the error)
Actually that's wrong as well, you just need to cast to unichar
