### PR TITLE
Add feedURL property to MWFeedInfo class

### DIFF
--- a/Classes/MWFeedInfo.h
+++ b/Classes/MWFeedInfo.h
@@ -34,11 +34,13 @@
 	NSString *title; // Feed title
 	NSString *link; // Feed link
 	NSString *summary; // Feed summary / description
+	NSURL *feedURL;
 	
 }
 
 @property (nonatomic, copy) NSString *title;
 @property (nonatomic, copy) NSString *link;
 @property (nonatomic, copy) NSString *summary;
+@property (nonatomic, copy) NSURL *feedURL;
 
 @end

--- a/Classes/MWFeedInfo.m
+++ b/Classes/MWFeedInfo.m
@@ -33,7 +33,7 @@
 
 @implementation MWFeedInfo
 
-@synthesize title, link, summary;
+@synthesize title, link, summary, feedURL;
 
 #pragma mark NSObject
 
@@ -49,6 +49,7 @@
 	[title release];
 	[link release];
 	[summary release];
+	[feedURL release];
 	[super dealloc];
 }
 
@@ -59,6 +60,7 @@
 		title = [[decoder decodeObjectForKey:@"title"] retain];
 		link = [[decoder decodeObjectForKey:@"link"] retain];
 		summary = [[decoder decodeObjectForKey:@"summary"] retain];
+		feedURL = [[decoder decodeObjectForKey:@"feedURL"] retain];
 	}
 	return self;
 }
@@ -67,6 +69,7 @@
 	if (title) [encoder encodeObject:title forKey:@"title"];
 	if (link) [encoder encodeObject:link forKey:@"link"];
 	if (summary) [encoder encodeObject:summary forKey:@"summary"];
+	if (feedURL) [encoder encodeObject:feedURL forKey:@"feedURL"];
 }
 
 @end

--- a/Classes/MWFeedParser.m
+++ b/Classes/MWFeedParser.m
@@ -204,6 +204,9 @@
 		
 		// Create feed info
 		MWFeedInfo *i = [[MWFeedInfo alloc] init];
+        
+		i.feedURL = self.url;
+        
 		self.info = i;
 		[i release];
 		


### PR DESCRIPTION
Generally speaking, it seems wise that since you can get a `MWFeedInfo` object from a
`MWFeedParser`, you should be able to reconstruct an `MWFeedParser` from an `MWFeedInfo`.
This pull request adds this functionality. Below is a common use case that demonstrates
this.

In a situation slightly more advanced than the provided demo, but a common scenario worth
accommodating in the library, you might have a list of several feeds, all of which
require their own `MWFeedParser`. If the list of `MWFeedParser` objects are in a table
view, and a particular feed is selected, you would likely pass the `MWFeedInfo` object
into the next view controller to display the feed items. However, `MWFeedInfo` does not
currently keep track of the URL it was retrieved from, which requires keeping track of it
separately or passing in the parser, neither of which are ideal. This pull request adds
a `feedURL` property to the `MWFeedInfo` object, allowing a view controller to construct
its own `MWFeedParser` with its own settings to retrieve the items.
