### PR TITLE
fix for encoding detection

### DIFF
--- a/Classes/MWFeedParser.m
+++ b/Classes/MWFeedParser.m
@@ -231,13 +231,14 @@
                 
                 // try to retrieve encoding from xml
                 if (!string) {
-                    string = [[NSString alloc] initWithData:data encoding:NSASCIIStringEncoding];
-                    if (string) {
+                    NSString *acsiiString = [[NSString alloc] initWithData:data encoding:NSASCIIStringEncoding];
+                    if (acsiiString) {
                         NSRegularExpression *xmlEncoding = [NSRegularExpression regularExpressionWithPattern:@"encoding=(\".*?\")" options:0 error:NULL];
-                        NSRange range = [xmlEncoding rangeOfFirstMatchInString:string
+                        NSRange range = [xmlEncoding rangeOfFirstMatchInString:acsiiString
                                                                        options:0
-                                                                         range:NSMakeRange(0, [[[string componentsSeparatedByString:@"\n"] objectAtIndex:0] length])];
-                        NSString *encoding = [string substringWithRange:range];
+                                                                         range:NSMakeRange(0, [[[acsiiString componentsSeparatedByString:@"\n"] objectAtIndex:0] length])];
+                        NSString *encoding = [acsiiString substringWithRange:range];
+                        [acsiiString release];
                         
                         if (encoding) {
                             NSRegularExpression *xmlEncodingFromString = [NSRegularExpression regularExpressionWithPattern:@"(\".*?\")" options:0 error:NULL];
@@ -252,9 +253,10 @@
                         MWLog(@"MWFeedParser: detected encoding : '%@' with value '%u'", encoding, nsEncoding);
                     }
                     string = [[NSString alloc] initWithData:data encoding:nsEncoding];
-                    data = [string dataUsingEncoding:nsEncoding];
+                    data = [string dataUsingEncoding:nsEncoding];                    
                 }
 			}
+            [string release];
 		}
 		
 		// Create NSXMLParser


### PR DESCRIPTION
Some optimization for encoding detection. I think there is no need to detect encoding manually, parser can do it for you, but I added some code for encoding detection from XML info header. Tested on some UTF-8 RSS and CP-1251 encoding (you can see diff at your head and my pull request at this link http://svpressa.ru/xml/news.xml).
See 9f57580 for memory leak fix. Sorry :)
