### PR TITLE
separate categories for NSDate/NSDateFormatter/NSString+InternetDateTime + rfc3339String

### DIFF
--- a/Classes/NSDate+InternetDateTime.h
+++ b/Classes/NSDate+InternetDateTime.h
@@ -18,6 +18,8 @@ typedef enum {
 // A category to parse internet date & time strings
 @interface NSDate (InternetDateTime)
 
+- (NSString* )rfc3339String;
+
 // Get date from RFC3339 or RFC822 string
 // - A format/specification hint can be used to speed up, 
 //   otherwise both will be attempted in order to get a date

--- a/Classes/NSDate+InternetDateTime.m
+++ b/Classes/NSDate+InternetDateTime.m
@@ -7,143 +7,41 @@
 //
 
 #import "NSDate+InternetDateTime.h"
+#import "NSDateFormatter+InternetDateTime.h"
+#import "NSString+InternetDateTime.h"
 
 // Good info on internet dates here:
 // http://developer.apple.com/iphone/library/qa/qa2010/qa1480.html
 @implementation NSDate (InternetDateTime)
 
-+ (NSDateFormatter const *)rfc3339InternetDateTimeGenerator {
-		static dispatch_once_t once;
-		static NSDateFormatter const * _rfc3339InternetDateTimeGenerator;
-		dispatch_once(&once, ^{
-			_rfc3339InternetDateTimeGenerator = [self internetDateTimeFormatter].copy;
-			_rfc3339InternetDateTimeGenerator.calendar
-			  = [[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar];
-			[_rfc3339InternetDateTimeGenerator setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss'Z'"];
-		});
-    return _rfc3339InternetDateTimeGenerator;
-}
-
-// Instantiate single date formatter
-+ (NSDateFormatter *)internetDateTimeFormatter {
-		static dispatch_once_t once;
-		static NSDateFormatter *_internetDateTimeFormatter;
-		dispatch_once(&once, ^{
-			NSLocale *en_US_POSIX = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"];
-			_internetDateTimeFormatter = [[NSDateFormatter alloc] init];
-			[_internetDateTimeFormatter setLocale:en_US_POSIX];
-			[_internetDateTimeFormatter setTimeZone:[NSTimeZone timeZoneForSecondsFromGMT:0]];
-		});
-    return _internetDateTimeFormatter;
-}
-
 - (NSString* )rfc3339String { 
-	return [[NSDate rfc3339InternetDateTimeGenerator] stringFromDate:self];
+	return [[NSDateFormatter rfc3339InternetDateTimeGenerator] stringFromDate:self];
 }
 
 // Get a date from a string - hint can be used to speed up
-+ (NSDate *)dateFromInternetDateTimeString:(NSString *)dateString formatHint:(DateFormatHint)hint {
++ (NSDate *)dateFromInternetDateTimeString:(NSString *)dateString
+								formatHint:(DateFormatHint)hint {
 	NSDate *date = nil;
-    if (dateString) {
-        if (hint != DateFormatHintRFC3339) {
-            // Try RFC822 first
-            date = [NSDate dateFromRFC822String:dateString];
-            if (!date) date = [NSDate dateFromRFC3339String:dateString];
-        } else {
-            // Try RFC3339 first
-            date = [NSDate dateFromRFC3339String:dateString];
-            if (!date) date = [NSDate dateFromRFC822String:dateString];
-        }
-    }
+	if (dateString) {
+		if (hint != DateFormatHintRFC3339) {
+			// Try RFC822 first
+			date = [dateString dateFromRFC822String];
+			if (!date) date = [dateString dateFromRFC3339String];
+		} else {
+			// Try RFC3339 first
+			date = [dateString dateFromRFC3339String];
+			if (!date) date = [dateString dateFromRFC822String];
+		}
+	}
 	return date;
 }
 
-// See http://www.faqs.org/rfcs/rfc822.html
 + (NSDate *)dateFromRFC822String:(NSString *)dateString {
-    NSDate *date = nil;
-    if (dateString) {
-        NSDateFormatter *dateFormatter = [NSDate internetDateTimeFormatter];
-        @synchronized(dateFormatter) {
-
-            // Process
-            NSString *RFC822String = [[NSString stringWithString:dateString] uppercaseString];
-            if ([RFC822String rangeOfString:@","].location != NSNotFound) {
-                if (!date) { // Sun, 19 May 2002 15:21:36 GMT
-                    [dateFormatter setDateFormat:@"EEE, d MMM yyyy HH:mm:ss zzz"]; 
-                    date = [dateFormatter dateFromString:RFC822String];
-                }
-                if (!date) { // Sun, 19 May 2002 15:21 GMT
-                    [dateFormatter setDateFormat:@"EEE, d MMM yyyy HH:mm zzz"]; 
-                    date = [dateFormatter dateFromString:RFC822String];
-                }
-                if (!date) { // Sun, 19 May 2002 15:21:36
-                    [dateFormatter setDateFormat:@"EEE, d MMM yyyy HH:mm:ss"]; 
-                    date = [dateFormatter dateFromString:RFC822String];
-                }
-                if (!date) { // Sun, 19 May 2002 15:21
-                    [dateFormatter setDateFormat:@"EEE, d MMM yyyy HH:mm"]; 
-                    date = [dateFormatter dateFromString:RFC822String];
-                }
-            } else {
-                if (!date) { // 19 May 2002 15:21:36 GMT
-                    [dateFormatter setDateFormat:@"d MMM yyyy HH:mm:ss zzz"]; 
-                    date = [dateFormatter dateFromString:RFC822String];
-                }
-                if (!date) { // 19 May 2002 15:21 GMT
-                    [dateFormatter setDateFormat:@"d MMM yyyy HH:mm zzz"]; 
-                    date = [dateFormatter dateFromString:RFC822String];
-                }
-                if (!date) { // 19 May 2002 15:21:36
-                    [dateFormatter setDateFormat:@"d MMM yyyy HH:mm:ss"]; 
-                    date = [dateFormatter dateFromString:RFC822String];
-                }
-                if (!date) { // 19 May 2002 15:21
-                    [dateFormatter setDateFormat:@"d MMM yyyy HH:mm"]; 
-                    date = [dateFormatter dateFromString:RFC822String];
-                }
-            }
-            if (!date) NSLog(@"Could not parse RFC822 date: \"%@\" Possible invalid format.", dateString);
-            
-        }
-    }
-    return date;
+	return [dateString dateFromRFC822String];
 }
 
-// See http://www.faqs.org/rfcs/rfc3339.html
 + (NSDate *)dateFromRFC3339String:(NSString *)dateString {
-    NSDate *date = nil;
-    if (dateString) {
-        NSDateFormatter *dateFormatter = [NSDate internetDateTimeFormatter];
-        @synchronized(dateFormatter) {
-            
-            // Process date
-            NSString *RFC3339String = [[NSString stringWithString:dateString] uppercaseString];
-            RFC3339String = [RFC3339String stringByReplacingOccurrencesOfString:@"Z" withString:@"-0000"];
-            // Remove colon in timezone as it breaks NSDateFormatter in iOS 4+.
-            // - see https://devforums.apple.com/thread/45837
-            if (RFC3339String.length > 20) {
-                RFC3339String = [RFC3339String stringByReplacingOccurrencesOfString:@":" 
-                                                                         withString:@"" 
-                                                                            options:0
-                                                                              range:NSMakeRange(20, RFC3339String.length-20)];
-            }
-			// 1996-12-19T16:39:57-0800
-            [dateFormatter setDateFormat:@"yyyy'-'MM'-'dd'T'HH':'mm':'ssZZZ"];
-            date = [dateFormatter dateFromString:RFC3339String];
-
-            if (!date) { // 1937-01-01T12:00:27.87+0020
-                [dateFormatter setDateFormat:@"yyyy'-'MM'-'dd'T'HH':'mm':'ss.SSSZZZ"]; 
-                date = [dateFormatter dateFromString:RFC3339String];
-            }
-            if (!date) { // 1937-01-01T12:00:27
-                [dateFormatter setDateFormat:@"yyyy'-'MM'-'dd'T'HH':'mm':'ss"]; 
-                date = [dateFormatter dateFromString:RFC3339String];
-            }
-            if (!date) NSLog(@"Could not parse RFC3339 date: \"%@\" Possible invalid format.", dateString);
-            
-        }
-    }
-	return date;
+	return [dateString dateFromRFC3339String];
 }
 
 @end

--- a/Classes/NSDateFormatter+InternetDateTime.h
+++ b/Classes/NSDateFormatter+InternetDateTime.h
@@ -1,0 +1,54 @@
+//
+//  NSDateFormatter+InternetDateTime.h
+//
+//  Created by kb on 2013.01.09.
+//  Copyright (c) 2013 xolaware.
+//
+//	Permission is hereby granted, free of charge, to any person obtaining a copy of this
+//	software and associated documentation files (the "Software"), to deal in the Software
+//	without restriction, including without limitation the rights to use, copy, modify, merge,
+//	publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+//	to whom the Software is furnished to do so, subject to the following conditions:
+//
+//	The above copyright notice and this permission notice shall be included in all copies or
+//	substantial portions of the Software.
+//
+//	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+//	INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+//	PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+//	FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+//	OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+//	DEALINGS IN THE SOFTWARE.
+
+// source derived from https://github.com/mwaterfall/MWFeedParser .  MIT based copyright chain:
+//
+//	Copyright (c) 2010 Michael Waterfall
+//
+//	Permission is hereby granted, free of charge, to any person obtaining a copy of this
+//	software and associated documentation files (the "Software"), to deal in the Software
+//	without restriction, including without limitation the rights to use, copy, modify, merge,
+//	publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+//	to whom the Software is furnished to do so, subject to the following conditions:
+//
+//	The above copyright notice and this permission notice shall be included in all copies or
+//	substantial portions of the Software.
+//
+//	This Software cannot be used to archive or collect data such as (but not limited to) that
+//	of events, news, experiences and activities, for the purpose of any concept relating to
+//	diary/journal keeping.
+//
+//	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+//	INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+//	PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+//	FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+//	OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+//	DEALINGS IN THE SOFTWARE.
+
+#import <Foundation/Foundation.h>
+
+@interface NSDateFormatter (InternetDateTime)
+
++ (NSDateFormatter const *)rfc3339InternetDateTimeGenerator;
++ (NSDateFormatter *)internetDateTimeFormatter;
+
+@end

--- a/Classes/NSDateFormatter+InternetDateTime.m
+++ b/Classes/NSDateFormatter+InternetDateTime.m
@@ -1,0 +1,76 @@
+//
+//  NSDateFormatter+InternetDateTime.m
+//
+//  Copyright (c) 2013 xolaware.
+//
+//	Permission is hereby granted, free of charge, to any person obtaining a copy of this
+//	software and associated documentation files (the "Software"), to deal in the Software
+//	without restriction, including without limitation the rights to use, copy, modify, merge,
+//	publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+//	to whom the Software is furnished to do so, subject to the following conditions:
+//
+//	The above copyright notice and this permission notice shall be included in all copies or
+//	substantial portions of the Software.
+//
+//	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+//	INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+//	PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+//	FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+//	OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+//	DEALINGS IN THE SOFTWARE.
+
+// source derived from https://github.com/mwaterfall/MWFeedParser .  MIT based copyright chain:
+//
+//	Copyright (c) 2010 Michael Waterfall
+//
+//	Permission is hereby granted, free of charge, to any person obtaining a copy of this
+//	software and associated documentation files (the "Software"), to deal in the Software
+//	without restriction, including without limitation the rights to use, copy, modify, merge,
+//	publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+//	to whom the Software is furnished to do so, subject to the following conditions:
+//
+//	The above copyright notice and this permission notice shall be included in all copies or
+//	substantial portions of the Software.
+//
+//	This Software cannot be used to archive or collect data such as (but not limited to) that
+//	of events, news, experiences and activities, for the purpose of any concept relating to
+//	diary/journal keeping.
+//
+//	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+//	INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+//	PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+//	FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+//	OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+//	DEALINGS IN THE SOFTWARE.
+
+
+#import "NSDateFormatter+InternetDateTime.h"
+
+@implementation NSDateFormatter (InternetDateTime)
+
++ (NSDateFormatter const *)rfc3339InternetDateTimeGenerator {
+	static dispatch_once_t once;
+	static NSDateFormatter const * _rfc3339InternetDateTimeGenerator;
+	dispatch_once(&once, ^{
+		_rfc3339InternetDateTimeGenerator = [self internetDateTimeFormatter].copy;
+		_rfc3339InternetDateTimeGenerator.calendar
+		= [[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar];
+		[_rfc3339InternetDateTimeGenerator setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss'Z'"];
+	});
+    return _rfc3339InternetDateTimeGenerator;
+}
+
+// Instantiate single date formatter
++ (NSDateFormatter *)internetDateTimeFormatter {
+	static dispatch_once_t once;
+	static NSDateFormatter *_internetDateTimeFormatter;
+	dispatch_once(&once, ^{
+		NSLocale *en_US_POSIX = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"];
+		_internetDateTimeFormatter = [[NSDateFormatter alloc] init];
+		[_internetDateTimeFormatter setLocale:en_US_POSIX];
+		[_internetDateTimeFormatter setTimeZone:[NSTimeZone timeZoneForSecondsFromGMT:0]];
+	});
+    return _internetDateTimeFormatter;
+}
+
+@end

--- a/Classes/NSString+InternetDateTime.h
+++ b/Classes/NSString+InternetDateTime.h
@@ -1,0 +1,56 @@
+//
+//  NSString+InternetDateTime.h
+//
+//  Copyright (c) 2013 xolaware.
+//
+//	Permission is hereby granted, free of charge, to any person obtaining a copy of this
+//	software and associated documentation files (the "Software"), to deal in the Software
+//	without restriction, including without limitation the rights to use, copy, modify, merge,
+//	publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+//	to whom the Software is furnished to do so, subject to the following conditions:
+//
+//	The above copyright notice and this permission notice shall be included in all copies or
+//	substantial portions of the Software.
+//
+//	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+//	INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+//	PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+//	FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+//	OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+//	DEALINGS IN THE SOFTWARE.
+
+// source derived from https://github.com/mwaterfall/MWFeedParser .  MIT based copyright chain:
+//
+//	Copyright (c) 2010 Michael Waterfall
+//
+//	Permission is hereby granted, free of charge, to any person obtaining a copy of this
+//	software and associated documentation files (the "Software"), to deal in the Software
+//	without restriction, including without limitation the rights to use, copy, modify, merge,
+//	publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+//	to whom the Software is furnished to do so, subject to the following conditions:
+//
+//	The above copyright notice and this permission notice shall be included in all copies or
+//	substantial portions of the Software.
+//
+//	This Software cannot be used to archive or collect data such as (but not limited to) that
+//	of events, news, experiences and activities, for the purpose of any concept relating to
+//	diary/journal keeping.
+//
+//	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+//	INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+//	PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+//	FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+//	OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+//	DEALINGS IN THE SOFTWARE.
+
+#import <Foundation/Foundation.h>
+
+@interface NSString (InternetDateTime)
+
+// Get date from a string using a specific date specification
+- (NSDate *)dateFromRFC3339String;
+- (NSDate *)dateFromRFC822String;
+
+- (NSString *)readableMediumLocalizedDateString;
+
+@end

--- a/Classes/NSString+InternetDateTime.m
+++ b/Classes/NSString+InternetDateTime.m
@@ -1,0 +1,145 @@
+//
+//  NSString+InternetDateTime.m
+//
+//  Copyright (c) 2013 xolaware.
+//
+//	Permission is hereby granted, free of charge, to any person obtaining a copy of this
+//	software and associated documentation files (the "Software"), to deal in the Software
+//	without restriction, including without limitation the rights to use, copy, modify, merge,
+//	publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+//	to whom the Software is furnished to do so, subject to the following conditions:
+//
+//	The above copyright notice and this permission notice shall be included in all copies or
+//	substantial portions of the Software.
+//
+//	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+//	INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+//	PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+//	FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+//	OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+//	DEALINGS IN THE SOFTWARE.
+
+// source derived from https://github.com/mwaterfall/MWFeedParser .  MIT based copyright chain:
+//
+//	Copyright (c) 2010 Michael Waterfall
+//
+//	Permission is hereby granted, free of charge, to any person obtaining a copy of this
+//	software and associated documentation files (the "Software"), to deal in the Software
+//	without restriction, including without limitation the rights to use, copy, modify, merge,
+//	publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+//	to whom the Software is furnished to do so, subject to the following conditions:
+//
+//	The above copyright notice and this permission notice shall be included in all copies or
+//	substantial portions of the Software.
+//
+//	This Software cannot be used to archive or collect data such as (but not limited to) that
+//	of events, news, experiences and activities, for the purpose of any concept relating to
+//	diary/journal keeping.
+//
+//	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+//	INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+//	PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+//	FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+//	OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+//	DEALINGS IN THE SOFTWARE.
+
+#import "NSString+InternetDateTime.h"
+#import "NSDateFormatter+InternetDateTime.h"
+
+@implementation NSString (InternetDateTime)
+
+- (NSString*)readableMediumLocalizedDateString {
+	return [NSDateFormatter localizedStringFromDate:[self dateFromRFC3339String]
+										  dateStyle:NSDateFormatterMediumStyle
+										  timeStyle:NSDateFormatterNoStyle];
+}
+
+// See http://www.faqs.org/rfcs/rfc822.html
+- (NSDate *)dateFromRFC822String {
+    NSDate *date = nil;
+	NSDateFormatter *dateFormatter = [NSDateFormatter internetDateTimeFormatter];
+	@synchronized(dateFormatter) {
+
+		// Process
+		NSString *RFC822String = [self uppercaseString];
+		if ([RFC822String rangeOfString:@","].location != NSNotFound) {
+			if (!date) { // Sun, 19 May 2002 15:21:36 GMT
+				[dateFormatter setDateFormat:@"EEE, d MMM yyyy HH:mm:ss zzz"];
+				date = [dateFormatter dateFromString:RFC822String];
+			}
+			if (!date) { // Sun, 19 May 2002 15:21 GMT
+				[dateFormatter setDateFormat:@"EEE, d MMM yyyy HH:mm zzz"];
+				date = [dateFormatter dateFromString:RFC822String];
+			}
+			if (!date) { // Sun, 19 May 2002 15:21:36
+				[dateFormatter setDateFormat:@"EEE, d MMM yyyy HH:mm:ss"];
+				date = [dateFormatter dateFromString:RFC822String];
+			}
+			if (!date) { // Sun, 19 May 2002 15:21
+				[dateFormatter setDateFormat:@"EEE, d MMM yyyy HH:mm"];
+				date = [dateFormatter dateFromString:RFC822String];
+			}
+		} else {
+			if (!date) { // 19 May 2002 15:21:36 GMT
+				[dateFormatter setDateFormat:@"d MMM yyyy HH:mm:ss zzz"];
+				date = [dateFormatter dateFromString:RFC822String];
+			}
+			if (!date) { // 19 May 2002 15:21 GMT
+				[dateFormatter setDateFormat:@"d MMM yyyy HH:mm zzz"];
+				date = [dateFormatter dateFromString:RFC822String];
+			}
+			if (!date) { // 19 May 2002 15:21:36
+				[dateFormatter setDateFormat:@"d MMM yyyy HH:mm:ss"];
+				date = [dateFormatter dateFromString:RFC822String];
+			}
+			if (!date) { // 19 May 2002 15:21
+				[dateFormatter setDateFormat:@"d MMM yyyy HH:mm"];
+				date = [dateFormatter dateFromString:RFC822String];
+			}
+		}
+		if (!date) NSLog(@"Could not parse RFC822 date: \"%@\" Possible invalid format.", self);
+
+	}
+    return date;
+}
+
+// See http://www.faqs.org/rfcs/rfc3339.html
+- (NSDate *)dateFromRFC3339String {
+    NSDate *date = nil;
+
+	NSDateFormatter *dateFormatter = [NSDateFormatter internetDateTimeFormatter];
+	@synchronized(dateFormatter) {
+
+		// Process date
+		NSString *RFC3339String = [self uppercaseString];
+		RFC3339String
+		  = [RFC3339String stringByReplacingOccurrencesOfString:@"Z" withString:@"-0000"];
+		// Remove colon in timezone as it breaks NSDateFormatter in iOS 4+.
+		// - see https://devforums.apple.com/thread/45837
+		NSRange range = NSMakeRange(20, RFC3339String.length-20);
+		if (RFC3339String.length > 20) {
+			RFC3339String = [RFC3339String stringByReplacingOccurrencesOfString:@":"
+																	 withString:@""
+																		options:0
+																		  range:range];
+		}
+		// 1996-12-19T16:39:57-0800
+		[dateFormatter setDateFormat:@"yyyy'-'MM'-'dd'T'HH':'mm':'ssZZZ"];
+		date = [dateFormatter dateFromString:RFC3339String];
+
+		if (!date) { // 1937-01-01T12:00:27.87+0020
+			[dateFormatter setDateFormat:@"yyyy'-'MM'-'dd'T'HH':'mm':'ss.SSSZZZ"];
+			date = [dateFormatter dateFromString:RFC3339String];
+		}
+		if (!date) { // 1937-01-01T12:00:27
+			[dateFormatter setDateFormat:@"yyyy'-'MM'-'dd'T'HH':'mm':'ss"];
+			date = [dateFormatter dateFromString:RFC3339String];
+		}
+		if (!date) NSLog(@"Could not parse RFC3339 date: \"%@\" Possible invalid format.", self);
+
+	}
+
+	return date;
+}
+
+@end


### PR DESCRIPTION
separating the categories was so that i could take a string that already existed and use .notation to get a readable string out of what i knew to already be an rfc3339String, using the standard iOS NSDateFormatter class members to get a medium localized date for generic usage.

these are mostly conveniences for me, but i figured i'd share them back since i have found them useful, and thought perhaps others might as well.
