### PR TITLE
Support Atom 0.3 date-time elements.

### DIFF
--- a/Classes/MWFeedParser.m
+++ b/Classes/MWFeedParser.m
@@ -656,8 +656,8 @@
                         else if ([currentPath isEqualToString:@"/feed/entry/content"]) { if (processedText.length > 0) item.content = processedText; processed = YES; }
                         else if ([currentPath isEqualToString:@"/feed/entry/author/name"]) { if (processedText.length > 0) item.author = processedText; processed = YES; }
                         else if ([currentPath isEqualToString:@"/feed/entry/dc:creator"]) { if (processedText.length > 0) item.author = processedText; processed = YES; }
-                        else if ([currentPath isEqualToString:@"/feed/entry/published"]) { if (processedText.length > 0) item.date = [NSDate dateFromInternetDateTimeString:processedText formatHint:DateFormatHintRFC3339]; processed = YES; }
-                        else if ([currentPath isEqualToString:@"/feed/entry/updated"]) { if (processedText.length > 0) item.updated = [NSDate dateFromInternetDateTimeString:processedText formatHint:DateFormatHintRFC3339]; processed = YES; }
+                        else if ([currentPath isEqualToString:@"/feed/entry/published"] || [currentPath isEqualToString:@"/feed/entry/created"] || [currentPath isEqualToString:@"/feed/entry/issued"]) { if (processedText.length > 0) item.date = [NSDate dateFromInternetDateTimeString:processedText formatHint:DateFormatHintRFC3339]; processed = YES; }
+                        else if ([currentPath isEqualToString:@"/feed/entry/updated"] || [currentPath isEqualToString:@"/feed/entry/modified"]) { if (processedText.length > 0) item.updated = [NSDate dateFromInternetDateTimeString:processedText formatHint:DateFormatHintRFC3339]; processed = YES; }
                     }
                     
                     // Info


### PR DESCRIPTION
Hi,

I created supporting Atom 0.3 date-time elements patch.
Atom 0.3 has no published & updated elements, has created / issued & modified elements.
So, I fix to parse also Atom 0.3 date-time elements.

Pleas check and pull this request.

Thanks.
