### PR TITLE
Fixed processing of atom links without a ‘rel’ attribute.

### DIFF
--- a/Classes/MWFeedParser.m
+++ b/Classes/MWFeedParser.m
@@ -926,21 +926,27 @@
 // Process ATOM link and determine whether to ignore it, add it as the link element or add as enclosure
 // Links can be added to MWObject (info or item)
 - (BOOL)processAtomLink:(NSDictionary *)attributes andAddToMWObject:(id)MWObject {
-	if (attributes && [attributes objectForKey:@"rel"]) {
-		
-		// Use as link if rel == alternate
-		if ([[attributes objectForKey:@"rel"] isEqualToString:@"alternate"]) {
-			[MWObject setLink:[attributes objectForKey:@"href"]]; // Can be added to MWFeedItem or MWFeedInfo
-			return YES;
-		}
-		
-		// Use as enclosure if rel == enclosure
-		if ([[attributes objectForKey:@"rel"] isEqualToString:@"enclosure"]) {
-			if ([MWObject isMemberOfClass:[MWFeedItem class]]) { // Enclosures can only be added to MWFeedItem
-				[self createEnclosureFromAttributes:attributes andAddToItem:(MWFeedItem *)MWObject];
-				return YES;
-			}
-		}
+    
+	if (attributes) {
+        
+        if ([attributes objectForKey:@"rel"]) {
+            // Use as link if rel == alternate
+            if ([[attributes objectForKey:@"rel"] isEqualToString:@"alternate"]) {
+                [MWObject setLink:[attributes objectForKey:@"href"]]; // Can be added to MWFeedItem or MWFeedInfo
+                return YES;
+            }
+            
+            // Use as enclosure if rel == enclosure
+            if ([[attributes objectForKey:@"rel"] isEqualToString:@"enclosure"]) {
+                if ([MWObject isMemberOfClass:[MWFeedItem class]]) { // Enclosures can only be added to MWFeedItem
+                    [self createEnclosureFromAttributes:attributes andAddToItem:(MWFeedItem *)MWObject];
+                    return YES;
+                }
+            }
+            
+        } else if ([attributes objectForKey:@"href"]) {
+            [MWObject setLink:[attributes objectForKey:@"href"]];
+        }
 		
 	}
 	return NO;


### PR DESCRIPTION
Atom links that had no 'rel' attribute weren't processed. 

http://tools.ietf.org/html/rfc4287#page-21

4.2.7.2.  The "rel" Attribute

   atom:link elements MAY have a "rel" attribute that indicates the link
   relation type.  If the "rel" attribute is not present, the link
   element MUST be interpreted as if the link relation type is
   "alternate".
