### PR TITLE
Detect language code in RSS feed format

### DIFF
--- a/Classes/MWFeedInfo.h
+++ b/Classes/MWFeedInfo.h
@@ -42,5 +42,6 @@
 @property (nonatomic, copy) NSString *link;
 @property (nonatomic, copy) NSString *summary;
 @property (nonatomic, copy) NSURL *url;
+@property (nonatomic, copy) NSString *language;
 
 @end

--- a/Classes/MWFeedInfo.m
+++ b/Classes/MWFeedInfo.m
@@ -33,7 +33,7 @@
 
 @implementation MWFeedInfo
 
-@synthesize title, link, summary, url;
+@synthesize title, link, summary, url, language;
 
 #pragma mark NSObject
 
@@ -54,6 +54,7 @@
 		link = [decoder decodeObjectForKey:@"link"];
 		summary = [decoder decodeObjectForKey:@"summary"];
 		url = [decoder decodeObjectForKey:@"url"];
+        language = [decoder decodeObjectForKey:@"language"];
 	}
 	return self;
 }
@@ -63,6 +64,7 @@
 	if (link) [encoder encodeObject:link forKey:@"link"];
 	if (summary) [encoder encodeObject:summary forKey:@"summary"];
 	if (url) [encoder encodeObject:url forKey:@"url"];
+    if (language) [encoder encodeObject:language forKey:@"language"];
 }
 
 @end

--- a/Classes/MWFeedParser.m
+++ b/Classes/MWFeedParser.m
@@ -610,6 +610,7 @@
                         if ([currentPath isEqualToString:@"/rss/channel/title"]) { if (processedText.length > 0) info.title = processedText; processed = YES; }
                         else if ([currentPath isEqualToString:@"/rss/channel/description"]) { if (processedText.length > 0) info.summary = processedText; processed = YES; }
                         else if ([currentPath isEqualToString:@"/rss/channel/link"]) { if (processedText.length > 0) info.link = processedText; processed = YES; }
+                        else if ([currentPath isEqualToString:@"/rss/channel/language"] || [currentPath isEqualToString:@"/rss/channel/dc:language"]) { if (processedText.length > 0) info.language = processedText; processed = YES; }
                     }
                     
                     break;


### PR DESCRIPTION
It detects the language code and store it as a new attribute (named language) in MWFeedInfo object. It is applicable for only  RSS type feed format for now.
