### PR TITLE
added subtitle in FeedInfo - atom only

### DIFF
--- a/Classes/MWFeedInfo.h
+++ b/Classes/MWFeedInfo.h
@@ -36,11 +36,14 @@
 	NSString *summary; // Feed summary / description
 	NSURL *url; // Feed url
 	
+	NSString *subtitle;
 }
 
 @property (nonatomic, copy) NSString *title;
 @property (nonatomic, copy) NSString *link;
 @property (nonatomic, copy) NSString *summary;
 @property (nonatomic, copy) NSURL *url;
+
+@property (nonatomic, copy) NSString *subtitle;
 
 @end

--- a/Classes/MWFeedInfo.m
+++ b/Classes/MWFeedInfo.m
@@ -34,6 +34,7 @@
 @implementation MWFeedInfo
 
 @synthesize title, link, summary, url;
+@synthesize subtitle;
 
 #pragma mark NSObject
 
@@ -54,6 +55,8 @@
 		link = [decoder decodeObjectForKey:@"link"];
 		summary = [decoder decodeObjectForKey:@"summary"];
 		url = [decoder decodeObjectForKey:@"url"];
+
+		subtitle = [decoder decodeObjectForKey:@"subtitle"];
 	}
 	return self;
 }
@@ -63,6 +66,8 @@
 	if (link) [encoder encodeObject:link forKey:@"link"];
 	if (summary) [encoder encodeObject:summary forKey:@"summary"];
 	if (url) [encoder encodeObject:url forKey:@"url"];
+
+	if (subtitle) [encoder encodeObject:title forKey:@"subtitle"];
 }
 
 @end

--- a/Classes/MWFeedParser.m
+++ b/Classes/MWFeedParser.m
@@ -665,6 +665,8 @@
                         if ([currentPath isEqualToString:@"/feed/title"]) { if (processedText.length > 0) info.title = processedText; processed = YES; }
                         else if ([currentPath isEqualToString:@"/feed/description"]) { if (processedText.length > 0) info.summary = processedText; processed = YES; }
                         else if ([currentPath isEqualToString:@"/feed/link"]) { [self processAtomLink:currentElementAttributes andAddToMWObject:info]; processed = YES;}
+
+                        else if ([currentPath isEqualToString:@"/feed/subtitle"]) { if (processedText.length > 0) info.subtitle = processedText; processed = YES; }
                     }
                     
                     break;

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+I'm working on YouTube feed parsing and I'd like to add support for some extra fields like info.subtitle.
+
+Documents: https://developers.google.com/youtube/2.0/developers_guide_protocol_playlists
+Example: https://gdata.youtube.com/feeds/api/playlists/PLvEIxIeBRKSjprrvlbAcbVjzHsnH9PjDX?v=2
+
 # MWFeedParser — An RSS and Atom web feed parser for iOS
 
 MWFeedParser is an Objective-C framework for downloading and parsing RSS (1.* and 2.*) and Atom web feeds. It is a very simple and clean implementation that reads the following information from a web feed:


### PR DESCRIPTION
In youtube atom feed, instead of description they are using subtitle so I created info.subtitle to support it. Please have a look cheers.
