### PR TITLE
Arbitrary load for transport, root view controller fix

### DIFF
--- a/Classes/MWFeedParserAppDelegate.m
+++ b/Classes/MWFeedParserAppDelegate.m
@@ -39,8 +39,10 @@
 #pragma mark Application lifecycle
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {    
-    // Override point for customization after app launch    
-	[window addSubview:[navigationController view]];
+    // Override point for customization after app launch
+    
+	// [window addSubview:[navigationController view]];
+    [self.window setRootViewController:navigationController];
     [window makeKeyAndVisible];
 	return YES;
 }

--- a/Classes/RootViewController.m
+++ b/Classes/RootViewController.m
@@ -59,7 +59,10 @@
 	// Parse
 //	NSURL *feedURL = [NSURL URLWithString:@"http://images.apple.com/main/rss/hotnews/hotnews.rss"];
 //	NSURL *feedURL = [NSURL URLWithString:@"http://feeds.mashable.com/Mashable"];
-	NSURL *feedURL = [NSURL URLWithString:@"http://techcrunch.com/feed/"];
+//	NSURL *feedURL = [NSURL URLWithString:@"http://techcrunch.com/feed/"];
+    NSURL *feedURL = [NSURL URLWithString:@"http://feeds.bbci.co.uk/news/rss.xml"];
+//    NSURL *feedURL = [NSURL URLWithString:@"http://blog.lelevier.com/feed.xml"];
+    
 	feedParser = [[MWFeedParser alloc] initWithFeedURL:feedURL];
 	feedParser.delegate = self;
 	feedParser.feedParseType = ParseTypeFull; // Parse feed info and all items

--- a/MWFeedParser-Info.plist
+++ b/MWFeedParser-Info.plist
@@ -28,6 +28,11 @@
 	<string>MainWindow</string>
 	<key>UIApplicationExitsOnSuspend</key>
 	<false/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>


### PR DESCRIPTION
Hi Michael,
builds with recent SDKs complain about missing root view controller
and I've added the arbitrary loads for transport security on iOS 9 , which make sense for an rss parser IMHO
( + leftover testing feed )
